### PR TITLE
Dev/3 create configuration with singletone

### DIFF
--- a/app/src/main/java/se/emilkronholm/pastaserver/App.java
+++ b/app/src/main/java/se/emilkronholm/pastaserver/App.java
@@ -12,8 +12,11 @@ public class App {
     public static void main(String[] args) {
         System.out.println(new App().getGreeting());
 
+        // Load default values
+        Config.loadShared(new Config.Builder());
+
         try {
-            InetSocketAddress address = new InetSocketAddress("127.0.0.1", 3500);
+            InetSocketAddress address = new InetSocketAddress(Config.getShared().getIp(), Config.getShared().getPort());
             ServerSocket serverSocket = new ServerSocket();
             serverSocket.bind(address);
             ConnectionManager.startServer(serverSocket);

--- a/app/src/main/java/se/emilkronholm/pastaserver/Config.java
+++ b/app/src/main/java/se/emilkronholm/pastaserver/Config.java
@@ -1,0 +1,75 @@
+package se.emilkronholm.pastaserver;
+
+import java.util.Optional;
+
+class Config {
+
+    // Public Static interface
+    static void loadShared(Builder configBuilder) {
+        shared = Optional.of(new Config(configBuilder));
+    }
+
+    static Config getShared() {
+        if (shared.isEmpty()) {
+            System.err.println("Config read before loading. Will use default config.");
+            loadShared(new Builder()); // Build new shared instance with empty configBuilder => default config.
+        }
+
+        return shared.get();
+    }
+
+
+
+
+    // Private attributes (accessible through getters)
+    private final int port;
+    private final String ip;
+    private final int timeout;
+
+    // Singleton instance
+    private static Optional<Config> shared = Optional.empty();
+
+    // Private constructor
+    private Config(Builder configBuilder) {
+        this.port = configBuilder.port;
+        this.ip = configBuilder.ip;
+        this.timeout = configBuilder.timeout;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    // Public ConfigBuilder, used to cleanly build new configs :)
+    public static class Builder {
+
+        // Parameters
+        private int port = 80;
+        private String ip = "127.0.0.1";
+        private int timeout = 10000;
+
+        // Setters
+        public Builder setPort(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder setIp(String ip) {
+            this.ip = ip;
+            return this;
+        }
+
+        public Builder setTimeout(int timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+    }
+}

--- a/app/src/main/java/se/emilkronholm/pastaserver/Connection.java
+++ b/app/src/main/java/se/emilkronholm/pastaserver/Connection.java
@@ -16,7 +16,7 @@ public class Connection {
     static void HandleConnection(Socket client) {
         try {
             // We set timeout to 10000 ms to make sure no bad clients will hog a Connection forever
-            client.setSoTimeout(10000);
+            client.setSoTimeout(Config.getShared().getTimeout());
         } catch (SocketException ex) {
             ex.printStackTrace();
         }

--- a/app/src/test/java/se/emilkronholm/pastaserver/ConfigTest.java
+++ b/app/src/test/java/se/emilkronholm/pastaserver/ConfigTest.java
@@ -1,0 +1,29 @@
+package se.emilkronholm.pastaserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+
+class ConfigTest {
+
+    @Test
+    void testConfigBuilder() {
+        int port = 5300;
+        String ip = "0.0.0.0";
+        
+
+        // We let timeout be default value
+        Config.Builder cb = new Config.Builder()
+                            .setIp(ip)
+                            .setPort(port);
+
+        Config.loadShared(cb);
+
+        assertEquals(Config.getShared().getPort(), port);
+        assertEquals(Config.getShared().getIp(), ip);
+
+        // Since timeout is default, make sure it has a value
+        assertNotNull(Config.getShared().getTimeout());
+        
+    }
+}


### PR DESCRIPTION
Finished an over-engineered Config class with singleton and builder pattern. Wrote basic test and integrated this solution in the rest of the app (very small integration at this step).

Now we can from anywhere write e.g. `Config.getShared().getIp()` and we have single source of truth.